### PR TITLE
Fix H2 table name and security bean

### DIFF
--- a/src/main/java/org/aidiary/config/SecurityConfig.java
+++ b/src/main/java/org/aidiary/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
     private final UserDetailsService userDetailsService;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // ✅ CORS 설정

--- a/src/main/java/org/aidiary/entity/User.java
+++ b/src/main/java/org/aidiary/entity/User.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Entity
-@Table(name = "users")
+@Table(name = "\"user\"")
 @Getter
 @Setter
 @Builder


### PR DESCRIPTION
## Summary
- quote `user` table name so H2 won't treat it as a reserved keyword
- rename `filterChain` bean to `securityFilterChain` to avoid conflicts

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f970aa66883329f7092f21bc43f24